### PR TITLE
docs: remove redundant $ from terminal command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
   
 First, check if you have `docker-compose` installed locally:
 ```bash
-$ docker-compose --version
+docker-compose --version
+``` 
+```
 docker-compose version 1.27.4, build 40524192
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,13 @@
 [Docker Engine for Linux](https://docs.docker.com/engine/install/#server)  
   
   
-First, check if you have `docker-compose` installed locally:
+First, check if you have `docker-compose` installed locally. 
+
+To do that, run this command in your terminal : 
 ```bash
 docker-compose --version
 ``` 
+Output should look something very similar to this : 
 ```
 docker-compose version 1.27.4, build 40524192
 ```


### PR DESCRIPTION
Removing the unnecessary $ from terminal commands.

Referring to : https://github.com/blockstack/docs/issues/1190 
