### PR TITLE
set postgres version to 13

### DIFF
--- a/configurations/common.yaml
+++ b/configurations/common.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   postgres:
-    image: postgres:alpine
+    image: postgres:13-alpine
     container_name: postgres
     restart: on-failure
     env_file:


### PR DESCRIPTION
data created for postgres 13 is incompatible with postgres 14

this hardcodes the postgres image to version 13


```
PostgreSQL Database directory appears to contain a database; Skipping initialization

2021-12-02 18:47:45.433 UTC [1] FATAL:  database files are incompatible with server
2021-12-02 18:47:45.433 UTC [1] DETAIL:  The data directory was initialized by PostgreSQL version 13, which is not compatible with this version 14.1.

```