### PR TITLE
Adding event-replay logic/changing service names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Stacks Blockchain with Docker
 ## Requirements:
+**MacOS with an M1 processor is *NOT* recommended for this repo**
+The way docker for mac on an Arm chip is designed makes the I/O incredibly slow, and blockchains are very heavy on I/O. This only seems to affect MacOS, other Arm based systems seem to work fine. 
+
 
 - [Docker](https://docs.docker.com/get-docker/)
 - [docker-compose](https://github.com/docker/compose/releases/) >= `1.27.4`
@@ -59,15 +62,12 @@ git clone https://github.com/blockstack/stacks-local-dev ./stacks-local-dev && c
 
 2. Create/Copy `.env` file
 *Use a symlink as an alternative to copying: `ln -s sample.env .env`*
+   - V1 BNS data is **not** imported by default. If you'd like to use BNS data, [uncomment this line](sample.env#L20) in your `.env` file: `BNS_IMPORT_DIR=/bns-data`
 ```bash
 cp sample.env .env
 ```
-1. V1 BNS data is **not** imported by default. If you'd like to use BNS data, [uncomment this line](sample.env#L20) in your `.env` file
-```
-BNS_IMPORT_DIR=/bns-data
-```
 
-4. Ensure all images are up to date
+3. Ensure all images are up to date
 ```bash
 ./manage.sh <network> pull
 ```
@@ -92,18 +92,38 @@ BNS_IMPORT_DIR=/bns-data
 ./manage.sh <network> restart
 ```
 
+7. Delete all data in `./persistent-data/<network>`:
+```bash
+./manage.sh <network> reset
+```
+
+8. export stacks-blockchain-api events (Not applicable for mocknet)
+```bash
+./manage.sh <network> export
+# check logs for completion
+./manage.sh <network> restart
+```
+
+
+9. replay stacks-blockchain-api events (Not applicable for mocknet)
+```bash
+./manage.sh <network> import
+# check logs for completion
+./manage.sh <network> restart
+```
+
 ## Accessing the services
 *Note*: For networks other than `mocknet`, downloading the initial headers can take several minutes. Until the headers are downloaded, the `/v2/info` endpoints won't return any data. 
 Use the command `./manage.sh <network> logs` to check the sync progress
 
-**stacks-node-follower**:
+**stacks-blockchain**:
 - Ports `20443-20444` are exposed to `localhost`
 
 ```bash
 curl localhost:20443/v2/info | jq
 ```
 
-**stacks-node-api**:
+**stacks-blockchain-api**:
 
 - Ports `3999` are exposed to `localhost`
 

--- a/configurations/api-export-events.yaml
+++ b/configurations/api-export-events.yaml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  stacks-blockchain-api:
+    restart: "no"
+    command: >
+      /bin/sh -c "
+      if [ -f $${STACKS_EXPORT_EVENTS_FILE} ]; then rm $${STACKS_EXPORT_EVENTS_FILE}; fi
+      && node ./lib/index.js export-events --file $${STACKS_EXPORT_EVENTS_FILE}"

--- a/configurations/api-import-events.yaml
+++ b/configurations/api-import-events.yaml
@@ -1,0 +1,7 @@
+version: "3"
+services:
+  stacks-blockchain-api:
+    restart: "no"
+    command: >
+      /bin/sh -c "
+      node ./lib/index.js import-events --file $${STACKS_EXPORT_EVENTS_FILE} --wipe-db --force"

--- a/configurations/common.yaml
+++ b/configurations/common.yaml
@@ -8,9 +8,12 @@ services:
         - ../.env
     networks:
       - stacks-blockchain
-  stacks-node-follower:
+    profiles: 
+      - event-replay
+      - stacks-blockchain
+  stacks-blockchain:
     image: blockstack/stacks-blockchain:latest
-    container_name: stacks-node-follower
+    container_name: stacks-blockchain
     restart: on-failure
     ports:
       - ${STACKS_FOLLOWER_RPC_PORT_LOCAL:-20443}:20443
@@ -18,15 +21,18 @@ services:
     networks:
       - stacks-blockchain
     depends_on:
-      - stacks-node-api
-    command: /bin/stacks-node start --config /src/stacks-node/Config.toml
-  stacks-node-api:
+      - stacks-blockchain-api
+    profiles: 
+      - stacks-blockchain
+    command: /bin/stacks-node start --config /src/stacks-blockchain/Config.toml
+  stacks-blockchain-api:
     image: blockstack/stacks-blockchain-api:latest
-    container_name: stacks-node-api
+    container_name: stacks-blockchain-api
     restart: always
     volumes:
       - ../persistent-data/bns-data:/bns-data
       - ../scripts:/scripts
+      - ../persistent-data/mainnet/event-replay:/tmp/event-replay
     ports:
       - ${API_STACKS_BLOCKCHAIN_API_PORT_LOCAL:-3999}:${API_STACKS_BLOCKCHAIN_API_PORT:-3999}
     env_file:
@@ -35,8 +41,11 @@ services:
       - stacks-blockchain
     depends_on:
       - postgres
+    profiles: 
+      - event-replay
+      - stacks-blockchain
+    command: npm run start
 networks:
   stacks-blockchain:
     driver: bridge
-    name: stacks-blockchain
-#
+    name: stacks

--- a/configurations/mainnet.yaml
+++ b/configurations/mainnet.yaml
@@ -3,10 +3,10 @@ services:
   postgres:
     volumes:
       - ../persistent-data/mainnet/postgres:/var/lib/postgresql/data
-  stacks-node-follower:
+  stacks-blockchain:
     volumes:
-      - ./mainnet:/src/stacks-node
-      - ../persistent-data/mainnet/stacks-blockchain:/root/stacks-node/data
-  stacks-node-api:
+      - ./mainnet:/src/stacks-blockchain
+      - ../persistent-data/mainnet/stacks-blockchain:/root/stacks-blockchain/data
+  stacks-blockchain-api:
     environment:
       - STACKS_CHAIN_ID=0x00000001

--- a/configurations/mainnet/Config.toml.sample
+++ b/configurations/mainnet/Config.toml.sample
@@ -1,27 +1,19 @@
 [node]
-working_dir = "/root/stacks-node/data"
+working_dir = "/root/stacks-blockchain/data"
 rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
 bootstrap_node = "02da7a464ac770ae8337a343670778b93410f2f3fef6bea98dd1c3e9224459d36b@seed-0.mainnet.stacks.co:20444,02afeae522aab5f8c99a00ddf75fbcb4a641e052dd48836408d9cf437344b63516@seed-1.mainnet.stacks.co:20444,03652212ea76be0ed4cd83a25c06e57819993029a7b9999f7d63c36340b34a4e62@seed-2.mainnet.stacks.co:20444"
-wait_time_for_microblocks = 10000
 
 [[events_observer]]
-endpoint = "stacks-node-api:3700"
+endpoint = "stacks-blockchain-api:3700"
 retry_count = 255
 events_keys = ["*"]
 
 [burnchain]
 chain = "bitcoin"
 mode = "mainnet"
-peer_host = "bitcoin.blockstack.com"
-username = "blockstack"
-password = "blockstacksystem"
+peer_host = "bitcoin.mainnet.stacks.org"
+username = "stacks"
+password = "foundation"
 rpc_port = 8332
 peer_port = 8333
-
-[connection_options]
-read_only_call_limit_write_length = 0
-read_only_call_limit_read_length = 100000
-read_only_call_limit_write_count = 0
-read_only_call_limit_read_count = 30
-read_only_call_limit_runtime = 1000000000

--- a/configurations/mocknet.yaml
+++ b/configurations/mocknet.yaml
@@ -1,5 +1,5 @@
 version: "3"
 services:
-  stacks-node-follower:
+  stacks-blockchain:
     volumes:
-      - ./mocknet:/src/stacks-node
+      - ./mocknet:/src/stacks-blockchain

--- a/configurations/mocknet/Config.toml.sample
+++ b/configurations/mocknet/Config.toml.sample
@@ -5,7 +5,7 @@ wait_time_for_microblocks = 10000
 use_test_genesis_chainstate = true
 
 [[events_observer]]
-endpoint = "stacks-node-api:3700"
+endpoint = "stacks-blockchain-api:3700"
 retry_count = 255
 events_keys = ["*"]
 

--- a/configurations/private-testnet.yaml
+++ b/configurations/private-testnet.yaml
@@ -1,22 +1,23 @@
 version: "3"
 services:
-  stacks-node-follower:
+  stacks-blockchain:
     image: blockstack/stacks-blockchain:feat-miner-control
     volumes:
-      - ./private-testnet:/src/stacks-node
-    # command: sh -c "sleep 60 && /bin/stacks-node start --config /src/stacks-node/Config.toml"
-    command: sh -c "until nc -vz bitcoin.stacks-blockchain 18443; do echo \"Waiting for bitcoin\"; sleep 2; done; /bin/stacks-node start --config /src/stacks-node/Config.toml"
+      - ./private-testnet:/src/stacks-blockchain
+    command: sh -c "until nc -vz bitcoin.stacks-blockchain 18443; do echo \"Waiting for bitcoin\"; sleep 2; done; /bin/stacks-node start --config /src/stacks-blockchain/Config.toml"
   explorer:
     image: blockstack/explorer:latest
     container_name: explorer
     environment:
-      - NEXT_PUBLIC_MAINNET_API_SERVER=http://stacks-node-api.stacks-blockchain:3999
-      - NEXT_PUBLIC_TESTNET_API_SERVER=http://stacks-node-api.stacks-blockchain:3399
+      - NEXT_PUBLIC_MAINNET_API_SERVER=http://stacks-blockchain-api.stacks:3999
+      - NEXT_PUBLIC_TESTNET_API_SERVER=http://stacks-blockchain-api.stacks:3399
       - MOCKNET_API_SERVER=http://localhost:3999
       - TESTNET_API_SERVER=http://localhost:3999
     ports:
       - 3000:3000
     networks:
+      - stacks-blockchain
+    profiles: 
       - stacks-blockchain
   bitcoin:
     image: blockstack/bitcoind:puppet-chain
@@ -31,4 +32,6 @@ services:
       - DYNAMIC_GENESIS_TIMESTAMP=1
       - RUST_BACKTRACE=1
     networks:
+      - stacks-blockchain
+    profiles: 
       - stacks-blockchain

--- a/configurations/private-testnet/Config.toml.sample
+++ b/configurations/private-testnet/Config.toml.sample
@@ -1,5 +1,5 @@
 [node]
-working_dir = "/root/stacks-node/data"
+working_dir = "/root/stacks-blockchain/data"
 rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
 bootstrap_node="047435c194e9b01b3d7f7a2802d6684a3af68d05bbf4ec8f17021980d777691f1d51651f7f1d566532c804da506c117bbf79ad62eea81213ba58f8808b4d9504ad@testnet.stacks.co:20444"
@@ -9,14 +9,14 @@ pox_sync_sample_secs = 0
 seed = "0000000000000000000000000000000000000000000000000000000000000000"
 
 [[events_observer]]
-endpoint = "stacks-node-api:3700"
+endpoint = "stacks-blockchain-api:3700"
 retry_count = 255
 events_keys = ["*"]
 
 [burnchain]
 chain = "bitcoin"
 mode = "krypton"
-peer_host = "bitcoin.stacks-blockchain"
+peer_host = "bitcoin.stacks"
 # Connect to puppet
 rpc_port = 18443
 # Connect direct to bitcoind (no firewall)

--- a/configurations/testnet.yaml
+++ b/configurations/testnet.yaml
@@ -3,10 +3,10 @@ services:
   postgres:
     volumes:
       - ../persistent-data/testnet/postgres:/var/lib/postgresql/data
-  stacks-node-follower:
+  stacks-blockchain:
     volumes:
-      - ./testnet:/src/stacks-node
-      - ../persistent-data/testnet/stacks-blockchain:/root/stacks-node/data
-  stacks-node-api:
+      - ./testnet:/src/stacks-blockchain
+      - ../persistent-data/testnet/stacks-blockchain:/root/stacks-blockchain/data
+  stacks-blockchain-api:
     environment:
       - STACKS_CHAIN_ID=0x80000000

--- a/configurations/testnet/Config.toml.sample
+++ b/configurations/testnet/Config.toml.sample
@@ -1,23 +1,22 @@
 [node]
-working_dir = "/root/stacks-node/data"
+working_dir = "/root/stacks-blockchain/data"
 rpc_bind = "0.0.0.0:20443"
 p2p_bind = "0.0.0.0:20444"
 bootstrap_node="047435c194e9b01b3d7f7a2802d6684a3af68d05bbf4ec8f17021980d777691f1d51651f7f1d566532c804da506c117bbf79ad62eea81213ba58f8808b4d9504ad@testnet.stacks.co:20444"
-wait_time_for_microblocks = 10000
-
-[[events_observer]]
-endpoint = "stacks-node-api:3700"
-retry_count = 255
-events_keys = ["*"]
 
 [burnchain]
 chain = "bitcoin"
 mode = "xenon"
-peer_host = "bitcoin.testnet.blockstack.com"
-username = "blockstack"
-password = "blockstacksystem"
+peer_host = "bitcoin.testnet.stacks.org"
+username = "stacks"
+password = "foundation"
 rpc_port = 18332
 peer_port = 18333
+
+[[events_observer]]
+endpoint = "stacks-blockchain-api:3700"
+retry_count = 255
+events_keys = ["*"]
 
 [[ustx_balance]]
 address = "ST2QKZ4FKHAH1NQKYKYAYZPY440FEPK7GZ1R5HBP2"
@@ -34,10 +33,3 @@ amount = 10000000000000000
 [[ustx_balance]]
 address = "ST2TFVBMRPS5SSNP98DQKQ5JNB2B6NZM91C4K3P7B"
 amount = 10000000000000000
-
-[connection_options]
-read_only_call_limit_write_length = 0
-read_only_call_limit_read_length = 100000
-read_only_call_limit_write_count = 0
-read_only_call_limit_read_count = 30
-read_only_call_limit_runtime = 1000000000

--- a/sample.env
+++ b/sample.env
@@ -17,6 +17,7 @@ STACKS_BLOCKCHAIN_API_HOST=0.0.0.0
 STACKS_BLOCKCHAIN_API_DB=pg
 STACKS_CORE_RPC_HOST=stacks-node-follower
 STACKS_CORE_RPC_PORT=20443
+STACKS_EXPORT_EVENTS_FILE=/tmp/event-replay/stacks-node-events.tsv
 #BNS_IMPORT_DIR=/bns-data
 
 ###############################


### PR DESCRIPTION
- import/export for the API event-replay functionality
- changing names from `stacks-node` to `stacks-blockchain` to reflect source repo/image names

On sync from genesis, event-replay file is created by default. 
To export the data, you can use the new arg `export`: `./manage.sh mainnet export` and the stacks-blockchain-api will run the export function to create the file from existing postgres data. 

to import the events from this file: `./manage.sh mainnet import` which will wipe the db, then recreate the tables/rows etc using the event replay file. 

both operations are singular - once they're done, the process ends and all services need to be restarted (not automatic). 

finally, the names of the services have been altered to reflect the git repo names: `stacks-node` -> `stacks-blockchain`
