### PR TITLE
Update stacks testnet node config to use correct burnchain epochs

### DIFF
--- a/conf/testnet/Config.toml.sample
+++ b/conf/testnet/Config.toml.sample
@@ -79,4 +79,12 @@ start_height = 6
 
 [[burnchain.epochs]]
 epoch_name = "3.0"
-start_height = 56_457
+start_height = 1_900
+
+[[burnchain.epochs]]
+epoch_name = "3.1"
+start_height = 2_000
+
+[[burnchain.epochs]]
+epoch_name = "3.2"
+start_height = 71_525


### PR DESCRIPTION
## Description

A stacks testnet node fails to start with this configuration, throwing a panic due to incorrect burnchain epoch configuration:

```
INFO [1758668797.581118] [stacks-node/src/run_loop/neon.rs:558] [main] Start syncing Bitcoin headers, feel free to grab a cup of coffee, this can take a while
ERRO [1758668797.583847] [stacks-node/src/main.rs:255] [main] Process abort due to thread panic: panicked at stackslib/src/chainstate/burn/db/sortdb.rs:3071:17:
FATAL: tried to retcon epoch StacksEpoch { epoch_id: Epoch25, start_height: 6, end_height: 1900, block_limit: ExecutionCost { write_length: 15000000, write_count: 15000, read_length: 100000000, read_count: 15000, runtime: 5000000000 }, network_epoch: 10 } into epoch StacksEpoch { epoch_id: Epoch25, start_height: 6, end_height: 56457, block_limit: ExecutionCost { write_length: 15000000, write_count: 15000, read_length: 100000000, read_count: 15000, runtime: 5000000000 }, network_epoch: 10 }
```

Updating to mirror the working version here:

https://docs.stacks.co/reference/sample-configuration-files#stacks-node-testnet-config

This was tested using `blockstack/stacks-core:3.2.0.0.1`

Use the following template to create your pull request


## Type of Change

- API reference/documentation update


## Does this introduce a breaking change?

No

