### PR TITLE
feat: remove docker version warnings

### DIFF
--- a/compose-files/common.yaml
+++ b/compose-files/common.yaml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   postgres:
     image: postgres:${POSTGRES_VERSION:-15}-alpine

--- a/compose-files/event-replay/api-export-events.yaml
+++ b/compose-files/event-replay/api-export-events.yaml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   stacks-blockchain-api:
     restart: "no"

--- a/compose-files/event-replay/api-import-events.yaml
+++ b/compose-files/event-replay/api-import-events.yaml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   stacks-blockchain-api:
     restart: "no"

--- a/compose-files/extra-services/bns.yaml
+++ b/compose-files/extra-services/bns.yaml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   bns:
     image: bash

--- a/compose-files/extra-services/postgres.yaml
+++ b/compose-files/extra-services/postgres.yaml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   postgres:
     ports:

--- a/compose-files/extra-services/proxy.yaml
+++ b/compose-files/extra-services/proxy.yaml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   nginx:
     image: nginx:alpine

--- a/compose-files/extra-services/signer.yaml
+++ b/compose-files/extra-services/signer.yaml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   stacks-signer:
     image: blockstack/stacks-signer:${STACKS_SIGNER_VERSION:-latest}

--- a/compose-files/networks/mainnet.yaml
+++ b/compose-files/networks/mainnet.yaml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   postgres:
     volumes:

--- a/compose-files/networks/mocknet.yaml
+++ b/compose-files/networks/mocknet.yaml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   stacks-blockchain:
     volumes:

--- a/compose-files/networks/testnet.yaml
+++ b/compose-files/networks/testnet.yaml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   postgres:
     volumes:


### PR DESCRIPTION
## Description

Remove the docker warnings shown when running the scripts:

```bash
WARN[0000] /root/stacks-blockchain-docker/compose-files/common.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @person1 or @person2
