### PR TITLE
fix: fix aria2c usage for absolute paths

### DIFF
--- a/scripts/seed-chainstate.sh
+++ b/scripts/seed-chainstate.sh
@@ -141,9 +141,12 @@ download_file(){
         aria2c \
             -x 10 \
             -s 10 \
+            --summary-interval=0 \
             --max-tries=10 \
             --retry-wait=5 \
-            "${url}" -o "${dest}" || exit_error "${COLRED}Error${COLRESET} downloading ${url} to ${dest}"
+            --dir="$(dirname "${dest}")" \
+            --out="$(basename "${dest}")" \
+            "${url}" || exit_error "${COLRED}Error${COLRESET} downloading ${url} to ${dest}"
     else
         # Fallback to curl
         curl -L -# \


### PR DESCRIPTION
## Description

The current download part with aria2c I submitted in the previous pr was missing this fix (sorry I didn't push the last change I had on my server it seems).
The -o flag is always relative (even with absolute paths) so we need to change the options to get it to work.

## Type of Change
- Bug fix


## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag @wileyj 
